### PR TITLE
Fix bug introduced by #858

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1371,7 +1371,7 @@ public class Server {
             case "v":
                 return Player.SPECTATOR;
         }
-        return Player.SURVIVAL;
+        return -1;
     }
 
     public static int getDifficultyFromString(String str) {


### PR DESCRIPTION
It should be -1 because it's used in commands to determine if the
input is valid.